### PR TITLE
refactor: Remove dark mode styles from rich-text CSS

### DIFF
--- a/src/app/(frontend)/style/_rich-text.css
+++ b/src/app/(frontend)/style/_rich-text.css
@@ -131,23 +131,3 @@
     @apply my-8 border-t border-gray-200;
   }
 }
-
-/* Dark mode overrides */
-[data-theme='dark'] .rich-text {
-  blockquote {
-    @apply bg-astral-900/20 border-astral-600;
-  }
-
-  pre,
-  code {
-    @apply bg-gray-800;
-  }
-
-  th {
-    @apply bg-gray-800;
-  }
-
-  hr {
-    @apply border-gray-700;
-  }
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated rich text content appearance by removing custom dark mode enhancements. Rich text elements such as blockquotes, code blocks, table headers, and horizontal rules now display using the default theme styling for a consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->